### PR TITLE
Incident/Interruption Data

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -133,7 +133,7 @@ app.intent(
             ) &&
             timetableCells.length >= 2
           ) {
-            conv.close(
+            return conv.close(
               new SimpleResponse({
                 speech: `The train after that is a ${
                   lineNamesEnum[timetable.predictions[1].Line]
@@ -161,56 +161,18 @@ app.intent(
             );
           }
 
-          if (timetable.incidents.length) {
-            conv.ask(
+          if (timetable.incidents.length > 0) {
+            const incidents = timetable.incidents
+              .map((incident) => incident.Description)
+              .join(' ');
+            return conv.close(
               `There are ${
                 timetable.incidents.length
-              } incidents affecting the lines which service this station.`
+              } incidents affecting the lines which service this station. \n ${incidents}
+              `
             );
-
-            if (
-              conv.surface.capabilities.has('actions.capability.SCREEN_OUTPUT')
-            ) {
-              const incidentCells = timetable.incidents.map((item) => {
-                return {
-                  cells: [
-                    item.IncidentType || 'TBD',
-                    item.Description || 'TDB',
-                  ],
-                };
-              });
-
-              conv.ask(
-                new Table({
-                  title: timetable.StopName,
-                  subtitle: new Date().toLocaleString('en-US', {
-                    timeZone: 'America/New_York',
-                  }),
-                  image: new Image({
-                    url:
-                      'https://raw.githubusercontent.com/JamesIves/dc-metro-google-assistant-action/master/assets/app_icon_large.png',
-                    alt: 'Metro Logo',
-                  }),
-                  columns: [
-                    {
-                      header: 'Incident',
-                      align: 'LEADING',
-                    },
-                    {
-                      header: 'Description',
-                    },
-                  ],
-                  rows: incidentCells,
-                })
-              );
-            } else {
-              timetable.incidents.map((incident) =>
-                conv.ask(incident.Description)
-              );
-              conv.close();
-            }
           } else {
-            conv.close();
+            return conv.close('There are no incidents affecting this station.');
           }
         }
       }
@@ -296,7 +258,7 @@ app.intent(
             ) &&
             timetableCells.length >= 2
           ) {
-            conv.close(
+            return conv.close(
               new SimpleResponse({
                 speech: `The bus after that is bound for ${
                   timetable.Predictions[1].DirectionText
@@ -311,7 +273,7 @@ app.intent(
               })
             );
           } else {
-            conv.close();
+            return conv.close();
           }
         }
       } else {
@@ -359,7 +321,7 @@ app.intent(
  * DiagFlow intent for cancel commands.
  */
 app.intent('goodbye_intent', (conv) => {
-  conv.close(`Have a good day!`);
+  return conv.close(`Have a good day!`);
 });
 
 exports.dcMetro = functions.https.onRequest(app);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,7 +7,7 @@ import {
   SimpleResponse,
 } from 'actions-on-google';
 import {lineNamesEnum, serviceCodesEnum, convertCode} from './util';
-import {fetchTrainTimetable, fetchBusTimetable} from './wmata';
+import {fetchTrainTimetable, fetchTrainIncidents, fetchBusTimetable} from './wmata';
 
 const app = dialogflow({debug: true});
 
@@ -28,6 +28,7 @@ app.intent(
       transportParam === 'metro'
     ) {
       const timetable: any = await fetchTrainTimetable(station);
+      const incidents: any = await fetchTrainIncidents();
 
       if (!timetable) {
         conv.ask(

--- a/functions/src/wmata.ts
+++ b/functions/src/wmata.ts
@@ -87,3 +87,16 @@ export const fetchBusTimetable = async (stop: string): Promise<object> => {
     return [];
   }
 };
+
+export const fetchTrainIncidents = async (): Promise<object> => {
+  try {
+    const incidentResponse = await fetch(
+      `${rootUrl}/Incidents.svc/json/Incidents&api_key${wmataApiKey}`,
+      {method: 'GET'}
+    );
+
+    return await incidentResponse.json();
+  } catch (error) {
+    return [];
+  }
+}

--- a/functions/src/wmata.ts
+++ b/functions/src/wmata.ts
@@ -57,9 +57,21 @@ export const fetchTrainTimetable = async (station: string): Promise<object> => {
           (item.Destination !== 'ssenger' && item.Destination !== 'Train')
       );
 
+      /* Applicable line codes are stored in seperate keys in the WMATA API. The following block
+        Checks all 4 and adds them to an array. This is later used to figure out if there's any
+        disruptions occuring at the station that is requested. */
+      const lines = [];
+      if (stationData.LineCode1 !== null) lines.push(stationData.LineCode1);
+      if (stationData.LineCode2 !== null) lines.push(stationData.lineCode2);
+      if (stationData.LineCode3 !== null) lines.push(stationData.LineCode3);
+      if (stationData.LineCode4 !== null) lines.push(stationData.LineCode4);
+
+      const incidents = await fetchTrainIncidents(lines);
+
       return {
         stationName: stationData.Name,
         predictions: predictionData,
+        incidents,
       };
     } else {
       return null;
@@ -88,15 +100,35 @@ export const fetchBusTimetable = async (stop: string): Promise<object> => {
   }
 };
 
-export const fetchTrainIncidents = async (): Promise<object> => {
+/**
+ * Accepts an array of line codes  and returns a string of incidents.
+ * @param {array} lines - An array of line codes, for example: ["RD", "BL"].
+ * @returns {Promise} Returns a promise.
+ */
+export const fetchTrainIncidents = async (
+  lines: Array<string>
+): Promise<object> => {
   try {
     const incidentResponse = await fetch(
       `${rootUrl}/Incidents.svc/json/Incidents&api_key${wmataApiKey}`,
       {method: 'GET'}
     );
 
-    return await incidentResponse.json();
+    const incidentObj = await incidentResponse.json();
+
+    return await incidentObj.Incidents.reduce((incidents, current) => {
+      const linesAffected = current.LinesAffected.split(/;[\s]?/).filter(
+        (code) => code !== ''
+      );
+      lines.map((line) => {
+        if (linesAffected.includes(line)) {
+          incidents.push(current);
+        }
+      });
+
+      return incidents;
+    }, []);
   } catch (error) {
     return [];
   }
-}
+};


### PR DESCRIPTION
**Description**
> Provide a description of what your changes do.

This PR reflects issue #12. This introduces data that is contained in WMATA's `Incidents` endpoint. If a user requests a station, for example Farragut North, and there's an incident affecting one of the lines that stop at that station, the action will now read off the incident alerting the user to any potential delays.

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

I'm hoping to get a beta version up for this on the Google Actions directory. The issue I'm running into is that I haven't been able to get the WMATA API to surface any incidents in the last day (The metro is running smoothly!)  so I want to hang tight before deploying it to production.

