### PR TITLE
Train Incident Fix

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,12 +7,8 @@ import {
   Suggestions,
   LinkOutSuggestion,
 } from 'actions-on-google';
-import {
-  lineNamesEnum,
-  serviceCodesEnum,
-  convertCode,
-  serviceIncidents,
-} from './util';
+import {lineNamesEnum, serviceCodesEnum, convertCode} from './util/constants';
+import {serviceIncidents} from './util/incidents';
 import {fetchTrainTimetable, fetchBusTimetable} from './wmata';
 
 const app = dialogflow({debug: true});

--- a/functions/src/tests/bus.spec.ts
+++ b/functions/src/tests/bus.spec.ts
@@ -1,0 +1,95 @@
+import * as test from 'tape';
+import {getRelevantBusIncidents} from '../util/bus';
+
+test('should get incidents that are relevant to the train lines in the station', (t: any) => {
+  t.plan(3);
+  const incidentData = {
+    BusIncidents: [
+      {
+        DateUpdated: '2014-10-28T08:13:03',
+        Description:
+          '90, 92, X1, X2, X9: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
+        IncidentID: '32297013-57B6-467F-BC6B-93DFA4115652',
+        IncidentType: 'Delay',
+        RoutesAffected: ['90', '92', 'X1', 'X2', 'X9'],
+      },
+      {
+        DateUpdated: '2014-10-28T08:13:03',
+        Description:
+          'PQ: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
+        IncidentID: '32297013-57B6-467F-BC6B-93DFA41156523',
+        IncidentType: 'Delay',
+        RoutesAffected: ['PQ'],
+      },
+      {
+        DateUpdated: '2014-10-28T08:13:03',
+        Description:
+          'JI: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
+        IncidentID: '2322970213-57B6-467F-BC6B-93DFA41156523',
+        IncidentType: 'Delay',
+        RoutesAffected: ['JI'],
+      },
+    ],
+  };
+
+  t.deepEquals(
+    getRelevantBusIncidents(['X2'], incidentData),
+    [
+      {
+        DateUpdated: '2014-10-28T08:13:03',
+        Description:
+          '90, 92, X1, X2, X9: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
+        IncidentID: '32297013-57B6-467F-BC6B-93DFA4115652',
+        IncidentType: 'Delay',
+        RoutesAffected: ['90', '92', 'X1', 'X2', 'X9'],
+      },
+    ],
+    'Should get incidents affecting X2 route.'
+  );
+
+  t.deepEquals(
+    getRelevantBusIncidents(['PQ', '92'], incidentData),
+    [
+      {
+        DateUpdated: '2014-10-28T08:13:03',
+        Description:
+          '90, 92, X1, X2, X9: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
+        IncidentID: '32297013-57B6-467F-BC6B-93DFA4115652',
+        IncidentType: 'Delay',
+        RoutesAffected: ['90', '92', 'X1', 'X2', 'X9'],
+      },
+      {
+        DateUpdated: '2014-10-28T08:13:03',
+        Description:
+          'PQ: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
+        IncidentID: '32297013-57B6-467F-BC6B-93DFA41156523',
+        IncidentType: 'Delay',
+        RoutesAffected: ['PQ'],
+      },
+    ],
+    'Should get incidents affecting PQ and 92 route.'
+  );
+
+  t.deepEquals(
+    getRelevantBusIncidents(['JI', 'PQ'], incidentData),
+    [
+      {
+        DateUpdated: '2014-10-28T08:13:03',
+        Description:
+          'PQ: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
+        IncidentID: '32297013-57B6-467F-BC6B-93DFA41156523',
+        IncidentType: 'Delay',
+        RoutesAffected: ['PQ'],
+      },
+      {
+        DateUpdated: '2014-10-28T08:13:03',
+        Description:
+          'JI: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
+        IncidentID: '2322970213-57B6-467F-BC6B-93DFA41156523',
+        IncidentType: 'Delay',
+        RoutesAffected: ['JI'],
+      },
+    ],
+    'Should get incidents affecting JI and PQ route.'
+  );
+});

--- a/functions/src/tests/constants.spec.ts
+++ b/functions/src/tests/constants.spec.ts
@@ -1,0 +1,52 @@
+import * as test from 'tape';
+import {lineNamesEnum, serviceCodesEnum, convertCode} from '../util/constants';
+
+test('should correctly convert the service and line codes', (t: any) => {
+  t.plan(8);
+
+  t.equal(
+    convertCode('ARR', serviceCodesEnum),
+    'Arriving',
+    'Should convert ARR to Arriving.'
+  );
+
+  t.equal(
+    convertCode('BRD', serviceCodesEnum),
+    'Boarding',
+    'Should convert BRD to Boarding.'
+  );
+
+  t.equal(convertCode('RD', lineNamesEnum), 'Red', 'Should convert RD to Red.');
+
+  t.equal(
+    convertCode('BL', lineNamesEnum),
+    'Blue',
+    'Should convert BL to Blue.'
+  );
+
+  t.equal(
+    convertCode('YL', lineNamesEnum),
+    'Yellow',
+    'Should convert YL to Yellow.'
+  );
+
+  t.equal(
+    convertCode('OR', lineNamesEnum),
+    'Orange',
+    'Should convert OR to Orange.'
+  );
+
+  t.equal(
+    convertCode('SV', lineNamesEnum),
+    'Silver',
+    'Should convert SV to Silver.'
+  );
+
+  t.equal(
+    convertCode('GR', lineNamesEnum),
+    'Green',
+    'Should convert Gr to Green.'
+  );
+
+  t.end();
+});

--- a/functions/src/tests/incidents.spec.ts
+++ b/functions/src/tests/incidents.spec.ts
@@ -1,0 +1,28 @@
+import * as test from 'tape';
+import {serviceIncidents} from '../util/incidents';
+
+test('should correctly store incidents and the station name as a global variable', (t: any) => {
+  serviceIncidents.setIncidents({
+    data: [
+      {name: 'Incident', station: 'U Street'},
+      {name: 'Another Incident', station: 'Mount Vernon'},
+    ],
+    name: 'Mount Vernon',
+    type: 'station',
+  });
+
+  t.deepEquals(
+    serviceIncidents.getIncidents(),
+    {
+      data: [
+        {name: 'Incident', station: 'U Street'},
+        {name: 'Another Incident', station: 'Mount Vernon'},
+      ],
+      name: 'Mount Vernon',
+      type: 'station',
+    },
+    'Correctly returns the value that was set.'
+  );
+
+  t.end();
+});

--- a/functions/src/tests/train.spec.ts
+++ b/functions/src/tests/train.spec.ts
@@ -1,65 +1,12 @@
 import * as test from 'tape';
 import {
-  convertCode,
+  combineLineCodes,
   convertStationAcronym,
-  lineNamesEnum,
-  serviceCodesEnum,
-  serviceIncidents,
   stationFuzzySearch,
+  stationPartialSearch,
   getRelevantTrainIncidents,
-  getRelevantBusIncidents,
   sortPredictions,
-} from '../util';
-
-test('should correctly convert the service and line codes', (t: any) => {
-  t.plan(8);
-
-  t.equal(
-    convertCode('ARR', serviceCodesEnum),
-    'Arriving',
-    'Should convert ARR to Arriving.'
-  );
-
-  t.equal(
-    convertCode('BRD', serviceCodesEnum),
-    'Boarding',
-    'Should convert BRD to Boarding.'
-  );
-
-  t.equal(convertCode('RD', lineNamesEnum), 'Red', 'Should convert RD to Red.');
-
-  t.equal(
-    convertCode('BL', lineNamesEnum),
-    'Blue',
-    'Should convert BL to Blue.'
-  );
-
-  t.equal(
-    convertCode('YL', lineNamesEnum),
-    'Yellow',
-    'Should convert YL to Yellow.'
-  );
-
-  t.equal(
-    convertCode('OR', lineNamesEnum),
-    'Orange',
-    'Should convert OR to Orange.'
-  );
-
-  t.equal(
-    convertCode('SV', lineNamesEnum),
-    'Silver',
-    'Should convert SV to Silver.'
-  );
-
-  t.equal(
-    convertCode('GR', lineNamesEnum),
-    'Green',
-    'Should convert Gr to Green.'
-  );
-
-  t.end();
-});
+} from '../util/train';
 
 test('should correctly convert acronyms for station searching', (t: any) => {
   t.plan(17);
@@ -169,35 +116,9 @@ test('should correctly convert acronyms for station searching', (t: any) => {
   t.end();
 });
 
-test('should correctly store incidents and the station name as a global variable', (t: any) => {
-  serviceIncidents.setIncidents({
-    data: [
-      {name: 'Incident', station: 'U Street'},
-      {name: 'Another Incident', station: 'Mount Vernon'},
-    ],
-    name: 'Mount Vernon',
-    type: 'station',
-  });
-
-  t.deepEquals(
-    serviceIncidents.getIncidents(),
-    {
-      data: [
-        {name: 'Incident', station: 'U Street'},
-        {name: 'Another Incident', station: 'Mount Vernon'},
-      ],
-      name: 'Mount Vernon',
-      type: 'station',
-    },
-    'Correctly returns the value that was set.'
-  );
-
-  t.end();
-});
-
 test('should correctly fuzzy match station queries to the correct station', (t: any) => {
   t.plan(3);
-  const stationData = {
+  const {Stations: stationData} = {
     Stations: [
       {
         Code: 'A01',
@@ -256,7 +177,7 @@ test('should correctly fuzzy match station queries to the correct station', (t: 
 
 test('should correctly partial match to a station', (t: any) => {
   t.plan(3);
-  const stationData = {
+  const {Stations: stationData} = {
     Stations: [
       {
         Code: 'A01',
@@ -280,7 +201,7 @@ test('should correctly partial match to a station', (t: any) => {
   };
 
   t.deepEquals(
-    stationFuzzySearch('Convention', stationData),
+    stationPartialSearch('Convention', stationData),
     {
       Code: 'A01',
       Name: 'Mt Vernon Sq 7th St-Convention',
@@ -291,7 +212,7 @@ test('should correctly partial match to a station', (t: any) => {
   );
 
   t.deepEquals(
-    stationFuzzySearch('Center', stationData),
+    stationPartialSearch('Center', stationData),
     {
       Code: 'A01',
       Name: 'Metro Center',
@@ -302,7 +223,7 @@ test('should correctly partial match to a station', (t: any) => {
   );
 
   t.deepEquals(
-    stationFuzzySearch('GMU', stationData),
+    stationPartialSearch('GMU', stationData),
     {
       Code: 'A01',
       Name: 'GMU',
@@ -430,99 +351,6 @@ test('should get incidents that are relevant to the train lines in the station',
       },
     ],
     'Should get incidents affecting the Silver line.'
-  );
-});
-
-test('should get incidents that are relevant to the train lines in the station', (t: any) => {
-  t.plan(3);
-  const incidentData = {
-    BusIncidents: [
-      {
-        DateUpdated: '2014-10-28T08:13:03',
-        Description:
-          '90, 92, X1, X2, X9: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
-        IncidentID: '32297013-57B6-467F-BC6B-93DFA4115652',
-        IncidentType: 'Delay',
-        RoutesAffected: ['90', '92', 'X1', 'X2', 'X9'],
-      },
-      {
-        DateUpdated: '2014-10-28T08:13:03',
-        Description:
-          'PQ: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
-        IncidentID: '32297013-57B6-467F-BC6B-93DFA41156523',
-        IncidentType: 'Delay',
-        RoutesAffected: ['PQ'],
-      },
-      {
-        DateUpdated: '2014-10-28T08:13:03',
-        Description:
-          'JI: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
-        IncidentID: '2322970213-57B6-467F-BC6B-93DFA41156523',
-        IncidentType: 'Delay',
-        RoutesAffected: ['JI'],
-      },
-    ],
-  };
-
-  t.deepEquals(
-    getRelevantBusIncidents(['X2'], incidentData),
-    [
-      {
-        DateUpdated: '2014-10-28T08:13:03',
-        Description:
-          '90, 92, X1, X2, X9: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
-        IncidentID: '32297013-57B6-467F-BC6B-93DFA4115652',
-        IncidentType: 'Delay',
-        RoutesAffected: ['90', '92', 'X1', 'X2', 'X9'],
-      },
-    ],
-    'Should get incidents affecting X2 route.'
-  );
-
-  t.deepEquals(
-    getRelevantBusIncidents(['PQ', '92'], incidentData),
-    [
-      {
-        DateUpdated: '2014-10-28T08:13:03',
-        Description:
-          '90, 92, X1, X2, X9: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
-        IncidentID: '32297013-57B6-467F-BC6B-93DFA4115652',
-        IncidentType: 'Delay',
-        RoutesAffected: ['90', '92', 'X1', 'X2', 'X9'],
-      },
-      {
-        DateUpdated: '2014-10-28T08:13:03',
-        Description:
-          'PQ: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
-        IncidentID: '32297013-57B6-467F-BC6B-93DFA41156523',
-        IncidentType: 'Delay',
-        RoutesAffected: ['PQ'],
-      },
-    ],
-    'Should get incidents affecting PQ and 92 route.'
-  );
-
-  t.deepEquals(
-    getRelevantBusIncidents(['JI', 'PQ'], incidentData),
-    [
-      {
-        DateUpdated: '2014-10-28T08:13:03',
-        Description:
-          'PQ: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
-        IncidentID: '32297013-57B6-467F-BC6B-93DFA41156523',
-        IncidentType: 'Delay',
-        RoutesAffected: ['PQ'],
-      },
-      {
-        DateUpdated: '2014-10-28T08:13:03',
-        Description:
-          'JI: Due to traffic congestion at 8th & H St NE, buses are experiencing up to 20 minute delays in both directions.',
-        IncidentID: '2322970213-57B6-467F-BC6B-93DFA41156523',
-        IncidentType: 'Delay',
-        RoutesAffected: ['JI'],
-      },
-    ],
-    'Should get incidents affecting JI and PQ route.'
   );
 });
 
@@ -812,4 +640,58 @@ test('should correctly sort arrival predictions in ascending order', (t) => {
   );
 
   t.end();
+});
+
+test('should correctly append the applicable line codes for each platform', (t) => {
+  t.plan(2);
+
+  const lines = [];
+  const firstPlatform = {
+    Code: 'A01',
+    Name: 'Metro Center',
+    StationTogether1: 'C01',
+    StationTogether2: '',
+    LineCode1: 'RD',
+    LineCode2: null,
+    LineCode3: null,
+    LineCode4: null,
+    Lat: 38.898303,
+    Lon: -77.028099,
+    Address: {
+      Street: '607 13th St. NW',
+      City: 'Washington',
+      State: 'DC',
+      Zip: '20005',
+    },
+  };
+  const secondPlatform = {
+    Code: 'C01',
+    Name: 'Metro Center',
+    StationTogether1: 'A01',
+    StationTogether2: '',
+    LineCode1: 'BL',
+    LineCode2: 'OR',
+    LineCode3: 'SV',
+    LineCode4: null,
+    Lat: 38.898303,
+    Lon: -77.028099,
+    Address: {
+      Street: '607 13th St. NW',
+      City: 'Washington',
+      State: 'DC',
+      Zip: '20005',
+    },
+  };
+
+  t.deepEquals(
+    combineLineCodes(lines, firstPlatform),
+    ['RD'],
+    'Should contain all of the line codes from the first platform.'
+  );
+
+  t.deepEquals(
+    combineLineCodes(lines, secondPlatform),
+    ['RD', 'BL', 'OR', 'SV'],
+    'Should contain all of the line codes from the first and second platform.'
+  );
 });

--- a/functions/src/util/bus.ts
+++ b/functions/src/util/bus.ts
@@ -1,0 +1,24 @@
+/**
+ * Filters bus incident data and returns a set of incidents which are relevant to the bus stop.
+ * @param {array} routes - An array of routes which arrive at this stop. For example ['ABC', 'EFG']
+ * @param {array} incidents - An array containing all of the incident data.
+ * @returns {array} Returns an array containing the matched incidents if they exist.
+ */
+export function getRelevantBusIncidents(
+  routes: Array<string>,
+  incidents: any
+): any {
+  return incidents.BusIncidents.reduce(
+    (incidentData: any[], current: any): any => {
+      const routesAffected = current.RoutesAffected;
+      routes.map((route) => {
+        if (routesAffected.includes(route)) {
+          incidentData.push(current);
+        }
+      });
+
+      return incidentData;
+    },
+    []
+  );
+}

--- a/functions/src/util/constants.ts
+++ b/functions/src/util/constants.ts
@@ -1,0 +1,56 @@
+/** Enum containing all of the service types the action supports. */
+export const serviceTypeEnum = {
+  TRAIN: 'train',
+  BUS: 'bus',
+};
+
+/** Enum containing all of the line names on the DC Metro. */
+export const lineNamesEnum = {
+  RD: 'Red',
+  BL: 'Blue',
+  YL: 'Yellow',
+  OR: 'Orange',
+  SV: 'Silver',
+  GR: 'Green',
+};
+
+/** Enum containing all service codes on the DC metro. */
+export const serviceCodesEnum = {
+  ARR: 'Arriving',
+  BRD: 'Boarding',
+  DLY: 'Delayed',
+};
+
+/** Enum containing all station acronyms and their matching string. */
+export const acronymEnum = {
+  MT: 'Mount',
+  AMER: 'American',
+  PL: 'Place',
+  UDC: 'University of the District of Columbia',
+  AU: 'American University',
+  AVE: 'Avenue',
+  CUA: 'Catholic University of America',
+  NOMA: 'North of Massachusetts Avenue',
+  GMU: 'George Mason University',
+  VT: 'Virginia Tech',
+  UVA: 'University of Virginia',
+  DCA: 'Ronald Reagan',
+  ST: 'Street',
+  SW: 'South West',
+  SQ: 'Square',
+  PENN: 'Pennsylvania',
+};
+
+/**
+ * Accepts a code and a dictionary enum, and returns the match.
+ * @param {string} code - The code that should be matched.
+ * @param {object} dictionary - The enum that the code should be matched to.
+ * @returns {string} Returns the matching string.
+ */
+export function convertCode(code: string, dictionary: object): string {
+  if (dictionary[code]) {
+    return dictionary[code];
+  } else {
+    return code;
+  }
+}

--- a/functions/src/util/incidents.ts
+++ b/functions/src/util/incidents.ts
@@ -1,0 +1,15 @@
+/** Object which contains all incidents so it can be passed back and forth between intents. */
+export const serviceIncidentsObj = {
+  incidents: {
+    name: null,
+    type: null,
+    data: [],
+  },
+};
+
+/** Sets/Fetches service incidents for intent pass backs. */
+export const serviceIncidents = {
+  setIncidents: (incidents: {name: any, type: any, data: any[]}) =>
+    (serviceIncidentsObj.incidents = incidents),
+  getIncidents: () => serviceIncidentsObj.incidents,
+};

--- a/functions/src/util/train.ts
+++ b/functions/src/util/train.ts
@@ -1,75 +1,4 @@
-/** Object which contains all incidents so it can be passed back and forth between intents. */
-export const serviceIncidentsObj = {
-  incidents: {
-    name: null,
-    type: null,
-    data: [],
-  },
-};
-
-/** Sets/Fetches service incidents for intent pass backs. */
-export const serviceIncidents = {
-  setIncidents: (incidents: {name: any, type: any, data: any[]}) =>
-    (serviceIncidentsObj.incidents = incidents),
-  getIncidents: () => serviceIncidentsObj.incidents,
-};
-
-/** Enum containing all of the service types the action supports. */
-export const serviceTypeEnum = {
-  TRAIN: 'train',
-  BUS: 'bus',
-};
-
-/** Enum containing all of the line names on the DC Metro. */
-export const lineNamesEnum = {
-  RD: 'Red',
-  BL: 'Blue',
-  YL: 'Yellow',
-  OR: 'Orange',
-  SV: 'Silver',
-  GR: 'Green',
-};
-
-/** Enum containing all service codes on the DC metro. */
-export const serviceCodesEnum = {
-  ARR: 'Arriving',
-  BRD: 'Boarding',
-  DLY: 'Delayed',
-};
-
-/** Enum containing all station acronyms and their matching string. */
-export const acronymEnum = {
-  MT: 'Mount',
-  AMER: 'American',
-  PL: 'Place',
-  UDC: 'University of the District of Columbia',
-  AU: 'American University',
-  AVE: 'Avenue',
-  CUA: 'Catholic University of America',
-  NOMA: 'North of Massachusetts Avenue',
-  GMU: 'George Mason University',
-  VT: 'Virginia Tech',
-  UVA: 'University of Virginia',
-  DCA: 'Ronald Reagan',
-  ST: 'Street',
-  SW: 'South West',
-  SQ: 'Square',
-  PENN: 'Pennsylvania',
-};
-
-/**
- * Accepts a code and a dictionary enum, and returns the match.
- * @param {string} code - The code that should be matched.
- * @param {object} dictionary - The enum that the code should be matched to.
- * @returns {string} Returns the matching string.
- */
-export function convertCode(code: string, dictionary: object): string {
-  if (dictionary[code]) {
-    return dictionary[code];
-  } else {
-    return code;
-  }
-}
+import {acronymEnum} from './constants';
 
 /**
  * Accepts a station name with acronyms and adjusts it to use the full version.
@@ -97,9 +26,9 @@ export function convertStationAcronym(stationName: string): string {
  * @returns {array} Returns an array containing the matched data if it exists.
  */
 export function stationFuzzySearch(query: string, stations: any): any {
-  const stationName = convertStationAcronym(query).toLowerCase();
+  const stationName = convertStationAcronym(query.toLowerCase()).toLowerCase();
   return (
-    stations.Stations.filter((item: {Name: string}) =>
+    stations.filter((item: {Name: string}) =>
       stationName.split(' ').every((word) =>
         convertStationAcronym(item.Name)
           .toLowerCase()
@@ -117,11 +46,42 @@ export function stationFuzzySearch(query: string, stations: any): any {
  */
 export function stationPartialSearch(query: string, stations: any): any {
   return (
-    stations.Stations.find(
+    stations.find(
       (item: {Name: {toLowerCase: () => {includes: (arg0: string) => void}}}) =>
-        item.Name.toLowerCase().includes(query)
+        item.Name.toLowerCase().includes(query.toLowerCase())
     ) || null
   );
+}
+
+/**
+ * Combines all applicable line codes that exist for a platform.
+ * @param {array} lines - The existing lines from other platforms.
+ * @param {object} platform - The stations platform data.
+ * @returns {array} Returns an array containing the concatenated line codes.
+ */
+export function combineLineCodes(
+  lines: any[],
+  platform: {LineCode1: any, LineCode2: any, LineCode3: any, LineCode4: any}
+): Array<string> {
+  const platformLines = [];
+
+  if (platform.LineCode1 !== null) {
+    lines.push(platform.LineCode1);
+  }
+
+  if (platform.LineCode2 !== null) {
+    lines.push(platform.LineCode2);
+  }
+
+  if (platform.LineCode3 !== null) {
+    lines.push(platform.LineCode3);
+  }
+
+  if (platform.LineCode4 !== null) {
+    lines.push(platform.LineCode4);
+  }
+
+  return lines.concat(platformLines);
 }
 
 /**
@@ -141,31 +101,6 @@ export function getRelevantTrainIncidents(
       );
       lines.map((line) => {
         if (linesAffected.includes(line)) {
-          incidentData.push(current);
-        }
-      });
-
-      return incidentData;
-    },
-    []
-  );
-}
-
-/**
- * Filters bus incident data and returns a set of incidents which are relevant to the bus stop.
- * @param {array} routes - An array of routes which arrive at this stop. For example ['ABC', 'EFG']
- * @param {array} incidents - An array containing all of the incident data.
- * @returns {array} Returns an array containing the matched incidents if they exist.
- */
-export function getRelevantBusIncidents(
-  routes: Array<string>,
-  incidents: any
-): any {
-  return incidents.BusIncidents.reduce(
-    (incidentData: any[], current: any): any => {
-      const routesAffected = current.RoutesAffected;
-      routes.map((route) => {
-        if (routesAffected.includes(route)) {
           incidentData.push(current);
         }
       });

--- a/functions/src/wmata.ts
+++ b/functions/src/wmata.ts
@@ -1,13 +1,14 @@
 import * as functions from 'firebase-functions';
 import fetch from 'node-fetch';
 import {
+  combineLineCodes,
   stationFuzzySearch,
   stationPartialSearch,
   getRelevantTrainIncidents,
-  getRelevantBusIncidents,
   sortPredictions,
-  serviceTypeEnum,
-} from './util';
+} from './util/train';
+import {getRelevantBusIncidents} from './util/bus';
+import {serviceTypeEnum} from './util/constants';
 
 export const rootUrl = 'https://api.wmata.com';
 export const wmataApiKey = functions.config().metro.apikey;
@@ -47,16 +48,15 @@ export const fetchTrainTimetable = async (station: string): Promise<object> => {
       `${rootUrl}/Rail.svc/json/jStations?api_key=${wmataApiKey}`,
       {method: 'GET'}
     );
-    const stations = await stationResponse.json();
+    const {Stations: stations} = await stationResponse.json();
 
     /* The station code is required for the secondary API call. First we check to see if we can find
       an exact match on the station name with an array find. If not the net is set wider and a fuzzy match filter
       is performed. */
-    const stationName = station.toLowerCase();
-    let stationData = stationPartialSearch(stationName, stations);
+    let stationData = stationPartialSearch(station, stations);
 
     if (!stationData) {
-      stationData = stationFuzzySearch(stationName, stations);
+      stationData = stationFuzzySearch(station, stations);
     }
 
     if (stationData) {
@@ -69,13 +69,25 @@ export const fetchTrainTimetable = async (station: string): Promise<object> => {
 
       const predictionObj = await predictionResponse.json();
 
+      /* Applicable line codes are stored in separate keys in the WMATA API. The following block
+        Checks all 4 and adds them to an array. This is later used to figure out if there's any
+        disruptions occurring at the station that is requested. */
+      let lines = combineLineCodes([], stationData);
+
       if (stationData.StationTogether1) {
         /* Some stations have multiple platforms, and the station code for these get stored in the
         StationTogether1 key. The following code fetches the prediction data for the multi platform station,
         adds it to the previous one, and then sorts it. */
+        const secondPlatform = stations.filter(
+          (platform: {Code: any}) =>
+            platform.Code === stationData.StationTogether1
+        )[0];
+
+        lines = combineLineCodes(lines, secondPlatform);
+
         const predictionResponseMulti = await fetch(
           `${rootUrl}/StationPrediction.svc/json/GetPrediction/${
-            stationData.StationTogether1
+            secondPlatform.Code
           }?api_key=${wmataApiKey}`,
           {method: 'GET'}
         );
@@ -95,27 +107,6 @@ export const fetchTrainTimetable = async (station: string): Promise<object> => {
           item.Line !== 'No' &&
           (item.Destination !== 'ssenger' && item.Destination !== 'Train')
       );
-
-      /* Applicable line codes are stored in separate keys in the WMATA API. The following block
-        Checks all 4 and adds them to an array. This is later used to figure out if there's any
-        disruptions occurring at the station that is requested. */
-      const lines = [];
-
-      if (stationData.LineCode1 !== null) {
-        lines.push(stationData.LineCode1);
-      }
-
-      if (stationData.LineCode2 !== null) {
-        lines.push(stationData.lineCode2);
-      }
-
-      if (stationData.LineCode3 !== null) {
-        lines.push(stationData.LineCode3);
-      }
-
-      if (stationData.LineCode4 !== null) {
-        lines.push(stationData.LineCode4);
-      }
 
       const incidentData = await fetchIncidents(serviceTypeEnum.TRAIN);
       const incidents = await getRelevantTrainIncidents(lines, incidentData);
@@ -160,7 +151,7 @@ export const fetchBusTimetable = async (stop: string): Promise<object> => {
       return {
         stopName: predictionObj.StopName,
         predictions: predictionObj.Predictions,
-        incidents
+        incidents,
       };
     } else {
       return null;


### PR DESCRIPTION
**Description**
> Provide a description of what your changes do.

FIxes an issue which prevented incidents from appearing for stations with multiple platforms. This was caused due to an incorrect key. `lineCode2` should of been `LineCode2`. I've branched this functionality into its own utility function and added some unit tests so it shouldn't happen again.

Also organized the code a little bit more so the util function doesn't contain everything, it's now segmented a little better. 

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

- Find a station with multiple platforms with current incident data, and ensure that the incident data gets read out.
